### PR TITLE
fix(workflows): unique per-user ID instead of shared 'default' namespace (v4.11.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "bettercallclaude",
       "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
-      "version": "4.11.0",
+      "version": "4.11.1",
       "source": "./bettercallclaude",
       "author": {
         "name": "Federico Cesconi"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BetterCallClaude will be documented in this file.
 
 ---
 
+## [4.11.1] - 2026-08-26
+
+### Fixed
+- **Unique per-user workflow namespace** — `/bettercallclaude:create-workflow` and `/bettercallclaude:workflow` no longer fall back to the shared `default` user ID when the `user_id` plugin setting is unset (Cowork Desktop exposes no userConfig editor, so every user would have shared one namespace). Resolution order is now: plugin setting → `user_id:` line in `~/.betterask/config.yaml` → generate a unique `bcc-<random>` ID once and persist it to that file. Every user gets a private namespace automatically, with no settings UI required.
+- Workflows previously saved under `default` are unaffected on the server but no longer listed; set the plugin setting (or the config-file line) to `default` explicitly if you need to reach them.
+
+---
+
 ## [4.11.0] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Version](https://img.shields.io/badge/version-4.11.0-blue)](https://github.com/fedec65/bettercallclaude/releases)
+[![Version](https://img.shields.io/badge/version-4.11.1-blue)](https://github.com/fedec65/bettercallclaude/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-green)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Cowork%20Desktop-orange)](https://claude.ai)
 [![Website](https://img.shields.io/badge/web-bettercallclaude.ch-brightgreen)](https://bettercallclaude.ch)
@@ -25,7 +25,9 @@ BetterCallClaude provides a structured methodology for handling legal work with 
 
 ---
 
-## What's New in v4.11.0
+## What's New in v4.11.1
+
+**v4.11.1 — Private workflow namespaces for everyone.** Custom workflows are now stored under a unique per-user ID: if you don't set the **User ID** plugin setting, a random `bcc-…` ID is generated once and saved to `~/.betterask/config.yaml`. No shared `default` namespace anymore.
 
 **v4.11.0 — Custom workflows.** Build your own multi-agent pipelines once and reuse them: `/bettercallclaude:create-workflow` interviews you, validates the agent chain server-side (compatible hand-offs only), and saves it; `/bettercallclaude:workflow` then lists your saved workflows next to the built-in templates and runs them with the same engine. Backed by the new `workflows-ch` MCP server (30 commands, 10 MCP servers total).
 

--- a/bettercallclaude/.claude-plugin/plugin.json
+++ b/bettercallclaude/.claude-plugin/plugin.json
@@ -1,8 +1,10 @@
 {
   "name": "bettercallclaude",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
-  "author": { "name": "Federico Cesconi" },
+  "author": {
+    "name": "Federico Cesconi"
+  },
   "userConfig": {
     "ollama_host": {
       "type": "string",
@@ -28,7 +30,7 @@
     "user_id": {
       "type": "string",
       "title": "User ID for custom workflows",
-      "description": "Stable identifier that owns your saved custom workflows (workflows-ch server). Pick something non-trivial (e.g. firm acronym + random suffix) — saved workflows are visible to anyone who knows the ID. Leave blank to use 'default'.",
+      "description": "Stable identifier that owns your saved custom workflows (workflows-ch server). Leave blank and a unique random ID is generated once and stored in ~/.betterask/config.yaml, so every user gets their own namespace automatically. Keep your ID private: saved workflows are visible to anyone who knows it.",
       "default": "",
       "sensitive": false
     },

--- a/bettercallclaude/commands/create-workflow.md
+++ b/bettercallclaude/commands/create-workflow.md
@@ -2,6 +2,7 @@
 description: "Create a reusable custom workflow by combining BetterCallClaude agents. Interview-based: pick agents, order them, define the output. Saved for future use with /bettercallclaude:workflow."
 tools:
   - Read
+  - Bash
   - mcp__plugin_bettercallclaude_workflows-ch__list_agents
   - mcp__plugin_bettercallclaude_workflows-ch__validate_pipeline
   - mcp__plugin_bettercallclaude_workflows-ch__save_workflow
@@ -11,9 +12,14 @@ tools:
 
 You guide the user through designing a reusable multi-agent workflow, validate it against the Swiss plugin's agent manifest, and save it for later execution with `/bettercallclaude:workflow <slug>`.
 
-## Current user
+## Resolve the user ID
 
-Use `${user_config.user_id}` as the `user_id` argument in every workflows-ch tool call. If that placeholder did not resolve (it appears literally) or resolved to an empty string, use `default` instead, and mention once — briefly — that the user can set a persistent **User ID for custom workflows** in the plugin settings to keep workflows private under their own ID.
+Every workflows-ch tool call takes a `user_id`. Resolve it in this order:
+
+1. **Plugin setting**: if `${user_config.user_id}` resolved to a non-empty value (i.e. the placeholder does not appear literally), use it.
+2. **Local config**: read `~/.betterask/config.yaml` if it exists. If it contains a `user_id:` line, use that value.
+3. **Generate once, then persist**: generate 8 random bytes of hex (e.g. `openssl rand -hex 8`) and build the ID `bcc-<hex>`. Persist it by **appending** the line `user_id: bcc-<hex>` to `~/.betterask/config.yaml` (run `mkdir -p ~/.betterask` first; append only — the file may already hold the user's privacy mode). Then tell the user once, briefly: "No User ID was set, so I generated a personal one (`bcc-…`) and saved it to `~/.betterask/config.yaml`. Your workflows are stored under this ID — keep it private: anyone who knows it can read your workflows."
+4. If the file cannot be written, ask the user to set the **User ID for custom workflows** plugin setting (or add a `user_id:` line to `~/.betterask/config.yaml` themselves) and stop. **Never** fall back to a shared `default` ID.
 
 ## Procedure
 

--- a/bettercallclaude/commands/version.md
+++ b/bettercallclaude/commands/version.md
@@ -22,7 +22,7 @@ Output the following formatted block:
 ======================================================
   BetterCallClaude - Swiss Legal Intelligence Plugin
 ======================================================
-  Version:      4.11.0
+  Version:      4.11.1
   Format:       Claude Code Plugin (Cowork Desktop)
   Author:       Federico Cesconi
   License:      AGPL-3.0

--- a/bettercallclaude/commands/workflow.md
+++ b/bettercallclaude/commands/workflow.md
@@ -96,10 +96,14 @@ Identify which template to use from the user's input, or let them choose:
 
 #### Your Saved Workflows
 
-Before presenting the template list, call `list_workflows` with:
+First resolve the `user_id`, in this order:
 
-- `user_id`: the value of `${user_config.user_id}`; if that placeholder did not resolve or is empty, use `default`.
-- `include_public`: `true`
+1. **Plugin setting**: if `${user_config.user_id}` resolved to a non-empty value (i.e. the placeholder does not appear literally), use it.
+2. **Local config**: read `~/.betterask/config.yaml` if it exists; if it contains a `user_id:` line, use that value.
+3. **Generate once, then persist**: generate 8 random bytes of hex (e.g. `openssl rand -hex 8`), build `bcc-<hex>`, and **append** `user_id: bcc-<hex>` to `~/.betterask/config.yaml` (`mkdir -p ~/.betterask` first; append only — the file may hold the user's privacy mode). Mention the generated ID to the user once, briefly.
+4. If the file cannot be written, skip this subsection entirely — **never** use a shared `default` ID.
+
+Then call `list_workflows` with that `user_id` and `include_public: true`.
 
 Present any returned workflows in the same numbered format as the fixed templates above (slug, name, description), numbered continuing after the fixed ones. If the call returns an empty list or fails (e.g. server unreachable), omit this subsection entirely without commenting on it.
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -157,7 +157,12 @@ Values declared in [`plugin.json` under `userConfig`](../bettercallclaude/.claud
 | `ollama_host`          | `settings.json` (plaintext)                     |
 | `default_jurisdiction` | `settings.json` (plaintext)                     |
 | `output_language`      | `settings.json` (plaintext)                     |
+| `user_id`              | `settings.json` (plaintext); if unset, a generated `bcc-<random>` ID in `~/.betterask/config.yaml` |
 | `api_token`            | OS keychain (macOS Keychain / Windows Credential Manager / libsecret) |
+
+The `user_id` value owns your saved custom workflows on the workflows-ch
+server. It is not a credential, but it is the only access key to your
+workflow namespace — treat it as semi-sensitive and do not share it.
 
 Gateway URLs (`mcp.bettercallclaude.ch`, `mcp.opencaselaw.ch`) are hardcoded
 in [`.mcp.json`](../bettercallclaude/.mcp.json); self-hosters fork and edit.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bettercallclaude",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "private": true,
   "description": "Swiss Legal Intelligence Plugin for Claude",
   "scripts": {


### PR DESCRIPTION
## Summary

v4.11.1 patch on top of #62. Cowork Desktop exposes no `userConfig` editor UI, so every Cowork user would have silently shared the `default` workflow namespace — readable and overwritable by anyone. That is unacceptable for a legal tool.

## Change

`user_id` resolution in `/bettercallclaude:create-workflow` and `/bettercallclaude:workflow` is now:

1. Plugin setting **User ID for custom workflows**, if set
2. `user_id:` line in `~/.betterask/config.yaml` (the existing per-user config file, same one `/bettercallclaude:privacy` writes), if present
3. Generate a unique `bcc-<16 hex chars>` ID once, **append** it to `~/.betterask/config.yaml` (never overwriting the file), and tell the user once

The shared `default` fallback is removed entirely. Server-side regex (`^[A-Za-z0-9._@-]+$`) accepts the generated format.

## Also

- `plugin.json` `user_id` description now documents the auto-generation
- PRIVACY.md: `user_id` storage locations + semi-sensitive guidance
- Version bump 4.11.0 → 4.11.1 (plugin.json, package.json, marketplace.json, version.md, README badge + What's New), CHANGELOG entry

## Notes

- Workflows previously saved under `default` remain on the server but are no longer listed; users can set their ID to `default` explicitly to reach them (documented in CHANGELOG).
- `create-workflow.md` gains `Bash` in its tool list (needed for the persist step); `workflow.md` already had it.

🤖 Generated with Kimi Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fedec65/bettercallclaude/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->