### PR TITLE
fix(ollama): drop user_config env that made Cowork drop the server (v4.11.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "bettercallclaude",
       "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
-      "version": "4.11.4",
+      "version": "4.11.5",
       "source": "./bettercallclaude",
       "author": {
         "name": "Federico Cesconi"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to BetterCallClaude will be documented in this file.
 
 ---
 
+## [4.11.5] - 2026-08-30
+
+### Fixed
+- **Ollama MCP server dropped entirely on Cowork Desktop** — `.mcp.json` passed `${user_config.ollama_host}` to the bundled ollama server, but Cowork Desktop's host bridge does not support `user_config` substitution in *any* field: it logged `config references plugin user configuration (ollama_host) — user_config is not supported on the desktop host bridge; dropping server` and never started the server, so the v4.11.4 in-server fallback never ran. The `env` block and the dead `ollama_host` plugin setting are removed; the server always runs against the default `http://localhost:11434`, and self-hosters edit `bettercallclaude/.mcp.json` directly.
+
+---
+
 ## [4.11.4] - 2026-08-30
 
 ### Fixed

--- a/CONNECTORS.md
+++ b/CONNECTORS.md
@@ -67,10 +67,7 @@ All nine servers auto-register via the `.mcp.json` file at the plugin root:
     },
     "ollama": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-servers/ollama/dist/index.js"],
-      "env": {
-        "OLLAMA_HOST": "${user_config.ollama_host}"
-      }
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-servers/ollama/dist/index.js"]
     }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,13 +143,13 @@ Expected: no output. Historical mentions in CHANGELOG, marketing, docs, and
   `haiku` for mechanical formatting, `sonnet` for everything else.
 - **Agents that spawn subagents must list `Task` as a tool.** The prompt
   alone is not enough; the subagent-runtime checks the tool list.
-- **Do not use `${user_config.*}` inside `url:` fields in `.mcp.json`.**
-  Cowork's server-side plugin validator rejects URL templating before the
-  user is prompted for `userConfig` values (see anthropic/claude-code#39455).
-  Hardcode the gateway URLs (`https://mcp.bettercallclaude.ch/...`,
-  `https://mcp.opencaselaw.ch`) and keep `${user_config.*}` substitution for
-  `env:`, `args:`, and `headers:` only. Self-hosters fork and edit
-  `.mcp.json` directly.
+- **Do not use `${user_config.*}` anywhere in `.mcp.json`.** Cowork Desktop's
+  host bridge does not resolve user_config substitution: a server whose entry
+  references it — in `url:`, `env:`, `args:`, or `headers:` — is **dropped
+  entirely** at load (`config references plugin user configuration (…) —
+  user_config is not supported on the desktop host bridge; dropping server`).
+  Hardcode the gateway URLs and the local defaults; self-hosters fork and
+  edit `.mcp.json` directly.
 - **Do not hardcode privacy patterns in the hook's strong list without
   word boundaries.** Weak markers (bare `confidential`, `vertraulich`,
   etc.) must be gated on a discriminator — see

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Version](https://img.shields.io/badge/version-4.11.4-blue)](https://github.com/fedec65/bettercallclaude/releases)
+[![Version](https://img.shields.io/badge/version-4.11.5-blue)](https://github.com/fedec65/bettercallclaude/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-green)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Cowork%20Desktop-orange)](https://claude.ai)
 [![Website](https://img.shields.io/badge/web-bettercallclaude.ch-brightgreen)](https://bettercallclaude.ch)
@@ -25,7 +25,9 @@ BetterCallClaude provides a structured methodology for handling legal work with 
 
 ---
 
-## What's New in v4.11.4
+## What's New in v4.11.5
+
+**v4.11.5 — Ollama server actually starts on Cowork Desktop.** The v4.11.4 fallback never ran: Cowork's host bridge drops any server whose `.mcp.json` entry references `${user_config.*}` (`user_config is not supported on the desktop host bridge; dropping server`), so the whole ollama server was rejected at load. The template and the dead `ollama_host` plugin setting are removed — the bundled server now starts and talks to your local Ollama daemon at `http://localhost:11434` directly. Update the plugin, restart Cowork, then run `/bettercallclaude:setup` to see the ollama server connected.
 
 **v4.11.4 — Ollama connector fixed on Cowork Desktop.** Since v4.3.0 the bundled ollama server received an empty `ollama_host` setting on Cowork (the app exposes no userConfig settings UI), which broke every local translation/summarisation call with `Failed to parse URL from /api/version`. The server now falls back to the default `http://localhost:11434` automatically — reinstall or update the plugin and no action is needed.
 

--- a/bettercallclaude/.claude-plugin/plugin.json
+++ b/bettercallclaude/.claude-plugin/plugin.json
@@ -1,18 +1,11 @@
 {
   "name": "bettercallclaude",
-  "version": "4.11.4",
+  "version": "4.11.5",
   "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
   "author": {
     "name": "Federico Cesconi"
   },
   "userConfig": {
-    "ollama_host": {
-      "type": "string",
-      "title": "Ollama host URL",
-      "description": "URL of the Ollama host used by the bundled ollama MCP server for local-only translation and summarisation.",
-      "default": "http://localhost:11434",
-      "sensitive": false
-    },
     "default_jurisdiction": {
       "type": "string",
       "title": "Default Swiss canton",

--- a/bettercallclaude/.mcp.json
+++ b/bettercallclaude/.mcp.json
@@ -38,10 +38,7 @@
     },
     "ollama": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-servers/ollama/dist/index.js"],
-      "env": {
-        "OLLAMA_HOST": "${user_config.ollama_host}"
-      }
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-servers/ollama/dist/index.js"]
     }
   }
 }

--- a/bettercallclaude/README.md
+++ b/bettercallclaude/README.md
@@ -6,7 +6,7 @@ BetterCallClaude is a plugin for legal professionals working in Cowork or Claude
 
 The plugin covers the full spectrum of Swiss legal work: BGE/ATF/DTF precedent research, case strategy development with risk assessment, adversarial legal analysis, compliance and data protection advisory, fiscal and corporate law expertise, real estate law, legal drafting with jurisdiction-aware templates, legal translation, and citation verification across all 26 Swiss cantons. Privacy compliance with Anwaltsgeheimnis (Art. 321 StGB) is enforced automatically through a pre-tool-use hook that detects privileged content before it leaves the local environment.
 
-**Version**: 4.11.4 -- 21 agents, 30 commands, 17 skills, 10 MCP servers.
+**Version**: 4.11.5 -- 21 agents, 30 commands, 17 skills, 10 MCP servers.
 
 > Love BetterCallClaude? Support the project — [**Buy me a coffee**](https://buymeacoffee.com/federicocesconi) ☕
 
@@ -443,9 +443,9 @@ The plugin ships pre-configured MCP servers that provide direct integration with
 
 - Node.js >= 20 (only required for local Ollama invocation; the other nine MCP servers are reached over HTTPS / SSE and run no code on your machine).
 
-Nine of the ten MCP servers are hosted remotely (eight HTTP servers at `mcp.bettercallclaude.ch`, one SSE server at `mcp.opencaselaw.ch`) and are reached by Cowork Desktop without any local build step. Only the local `ollama` server runs from a committed compiled bundle at `bettercallclaude/mcp-servers/ollama/dist/index.js`; to use it you need a running Ollama daemon (default `http://localhost:11434`, overridable via the `ollama_host` userConfig key).
+Nine of the ten MCP servers are hosted remotely (eight HTTP servers at `mcp.bettercallclaude.ch`, one SSE server at `mcp.opencaselaw.ch`) and are reached by Cowork Desktop without any local build step. Only the local `ollama` server runs from a committed compiled bundle at `bettercallclaude/mcp-servers/ollama/dist/index.js`; to use it you need a running Ollama daemon (default `http://localhost:11434`, configured in `.mcp.json` — self-hosters edit `bettercallclaude/.mcp.json` to point at a different host).
 
-All server paths and URLs are configured in `.mcp.json` using the `${CLAUDE_PLUGIN_ROOT}` and `${user_config.*}` interpolations for portability and self-hosting (see [`docs/PRIVACY.md`](../docs/PRIVACY.md)).
+All server paths and URLs are configured in `.mcp.json` using the `${CLAUDE_PLUGIN_ROOT}` interpolation for portability and self-hosting (see [`docs/PRIVACY.md`](../docs/PRIVACY.md)).
 
 ---
 

--- a/bettercallclaude/commands/help.md
+++ b/bettercallclaude/commands/help.md
@@ -224,7 +224,7 @@ Skills activate automatically when Claude detects relevant context.
 
 ---
 
-**BetterCallClaude v4.11.4 -- Swiss Legal Intelligence for Cowork Desktop**
+**BetterCallClaude v4.11.5 -- Swiss Legal Intelligence for Cowork Desktop**
 
 If the user provided additional input, respond to it in the context of this help reference.
 

--- a/bettercallclaude/commands/version.md
+++ b/bettercallclaude/commands/version.md
@@ -22,7 +22,7 @@ Output the following formatted block:
 ======================================================
   BetterCallClaude - Swiss Legal Intelligence Plugin
 ======================================================
-  Version:      4.11.4
+  Version:      4.11.5
   Format:       Claude Code Plugin (Cowork Desktop)
   Author:       Federico Cesconi
   License:      AGPL-3.0

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -61,11 +61,10 @@ One server runs **locally**:
 | `ollama` | STDIO     | `node ${CLAUDE_PLUGIN_ROOT}/mcp-servers/ollama/dist/index.js` |
 
 The Ollama subserver talks to a local Ollama daemon you operate (default
-`http://localhost:11434`, overridable via the `ollama_host`
-[userConfig](../bettercallclaude/.claude-plugin/plugin.json) key). It does not
-send data to the plugin author or to `bettercallclaude.ch`. It does send data
-to wherever you point `ollama_host`; if you change it to a remote host, the
-privacy properties of that host are your responsibility.
+`http://localhost:11434`, configurable in
+[`.mcp.json`](../bettercallclaude/.mcp.json)). It does not send data to the
+plugin author or to `bettercallclaude.ch`. If you point it at a remote host,
+the privacy properties of that host are your responsibility.
 
 ### 1.3 Anthropic
 
@@ -154,7 +153,6 @@ Values declared in [`plugin.json` under `userConfig`](../bettercallclaude/.claud
 
 | Key                    | Stored where                                    |
 | ---------------------- | ----------------------------------------------- |
-| `ollama_host`          | `settings.json` (plaintext)                     |
 | `default_jurisdiction` | `settings.json` (plaintext)                     |
 | `output_language`      | `settings.json` (plaintext)                     |
 | `user_id`              | `settings.json` (plaintext); if unset, a generated `bcc-<random>` ID in `~/.betterask/config.yaml` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bettercallclaude",
-  "version": "4.11.4",
+  "version": "4.11.5",
   "private": true,
   "description": "Swiss Legal Intelligence Plugin for Claude",
   "scripts": {


### PR DESCRIPTION
## v4.11.5 — ollama MCP server dropped by Cowork Desktop host bridge

### Problem

Since v4.3.0, `.mcp.json` passed `${user_config.ollama_host}` to the bundled ollama server. The v4.11.4 fallback in `client.ts` was never reached on Cowork Desktop because the host bridge **drops the entire server** when *any* field of an `.mcp.json` entry references `${user_config.*}`:

```
[PluginMcpHostConfig] Plugin "plugin_01EQftkohAhLjCgBx6nE3RPN" server "ollama":
config references plugin user configuration (ollama_host) — user_config is
not supported on the desktop host bridge; dropping server
```

Result: `ollama_check_status` and friends are absent; `/doctor` reports the ollama server missing.

### Fix

- Remove the `env: { OLLAMA_HOST: "${user_config.ollama_host}" }` block from the ollama entry in `bettercallclaude/.mcp.json`. The bundled server now always starts and talks to the local daemon at the default `http://localhost:11434` (the in-server fallback from v4.11.4 still honours an explicit host for CLI/self-hosters).
- Remove the dead `ollama_host` userConfig key from `bettercallclaude/.claude-plugin/plugin.json`.
- Docs: `README.md` (plugin + repo), `docs/PRIVACY.md`, `CONNECTORS.md` — no more `ollama_host` userConfig; self-hosters edit `.mcp.json` directly.
- `CONTRIBUTING.md`: the `${user_config.*}` ban now covers **any** field (`url:`, `env:`, `args:`, `headers:`), with the exact "dropping server" log line as the why.

### Testing

- `node bettercallclaude/scripts/privacy-check.test.js` → 82 passed.
- `bash scripts/package-plugin.sh` → `dist/bettercallclaude-4.11.5.zip` (756K); verified inside the zip: ollama entry has no `env`/`user_config`, `plugin.json` userConfig has no `ollama_host`, `mcp-servers/ollama/dist/index.js` present.
- Empirical on Cowork Desktop pending user update: expected outcome is the ollama server appearing connected in `/bettercallclaude:setup` (falls back to checking VM→host network reachability if "Cannot connect to Ollama at http://localhost:11434").

### Scope

- This repo (plugin) only — no MCP server behaviour changes.
- No userConfig settings UI impact: `ollama_host` was already non-functional on Cowork; CLI users with a custom host keep working via `OLLAMA_HOST` env (documented for self-hosters in `.mcp.json`).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fedec65/bettercallclaude/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->