### PR TITLE
fix(briefing): flatten panel dispatch to command so it runs on Cowork (v4.11.7)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "bettercallclaude",
       "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
-      "version": "4.11.6",
+      "version": "4.11.7",
       "source": "./bettercallclaude",
       "author": {
         "name": "Federico Cesconi"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to BetterCallClaude will be documented in this file.
 
 ---
 
+## [4.11.7] - 2026-09-01
+
+### Fixed
+- **Briefing coordinator's panel dispatch never ran on Cowork Desktop** — `/bettercallclaude:briefing` invoked the `swiss-legal-briefing-coordinator` agent, which then spawned the specialist panel via `Task` *inside its own subagent context*. Cowork's host grants `Task` only to the top-level session, not to nested subagents, so every panel dispatch was a no-op: the coordinator fell back to synthesising the panel's questions itself and printed *"Running in single-agent mode — questions synthesized from panel perspectives."* in the plan — a flag that was easy to miss because the brief still looked complete. User reporter saw the symptom directly: the panel questions came from the coordinator's voice rather than from the named specialists, and the resulting execution plan was a single-agent synthesis. v4.11.6 added `Task` to the briefing agent's whitelist (commit `9c26273`), but that fix only works if Task dispatch is reachable from where the spawn happens — it is not, inside nested subagents on Cowork. The plugin now **flattens the briefing flow**: `/bettercallclaude:briefing` (the top-level command) owns panel dispatch via `Task` at the session level (where it works on every host), and the coordinator becomes a pure planner with two explicit modes — Mode A classifies the query and returns the panel roster, Mode D takes the Q&A history and returns the structured execution plan (or signals "too foggy for a static plan"). The coordinator's `Task` frontmatter entry is removed: it was misleading (worked on hosts where it's not actually used) and would have invited future regressions. Files: `bettercallclaude/commands/briefing.md` (added `Task` to frontmatter, rewrote "New Briefing" into Phases A–F), `bettercallclaude/agents/briefing.md` (removed `Task`, restructured into two modes, moved memory schema to the command).
+
 ## [4.11.6] - 2026-08-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Version](https://img.shields.io/badge/version-4.11.6-blue)](https://github.com/fedec65/bettercallclaude/releases)
+[![Version](https://img.shields.io/badge/version-4.11.7-blue)](https://github.com/fedec65/bettercallclaude/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-green)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Cowork%20Desktop-orange)](https://claude.ai)
 [![Website](https://img.shields.io/badge/web-bettercallclaude.ch-brightgreen)](https://bettercallclaude.ch)
@@ -25,9 +25,9 @@ BetterCallClaude provides a structured methodology for handling legal work with 
 
 ---
 
-## What's New in v4.11.6
+## What's New in v4.11.7
 
-**v4.11.6 — Agents reach the legal databases on every install.** On some Cowork Desktop installs the connectors register under plain names (`mcp__fedlex-sparql__…`) instead of the plugin-scoped ones (`mcp__plugin_bettercallclaude_fedlex-sparql__…`), so every agent's tool whitelist matched nothing: plugin agents failed each database call with `Error: No such tool available`, while direct questions, generic agents, and inline commands worked. Every agent, skill, and command now whitelists each MCP tool under **both** names — update the plugin and re-run your agent task; no other action needed.
+**v4.11.7 — Briefing panels actually run on Cowork Desktop.** `/bettercallclaude:briefing` used to spawn the specialist panel from inside the briefing coordinator (a nested subagent); Cowork's host does not grant the `Task` tool to nested subagents, so the panel dispatch silently fell back to a "single-agent mode" synthesised by the coordinator — no real specialist input, and the brief looked plausible enough that nothing surfaced. The command now owns panel dispatch via `Task` at the top-level session (where it works on every host), and the coordinator becomes a pure planner: it classifies the query, selects the panel (Mode A), then takes the Q&A history and builds the execution plan (Mode D). If you used `/briefing` and felt the output was a generic synthesis rather than a real panel consult, reinstall and try the same query — the panel questions will now come from the named specialists.
 
 ## What's New in v4.11.5
 

--- a/bettercallclaude/.claude-plugin/plugin.json
+++ b/bettercallclaude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bettercallclaude",
-  "version": "4.11.6",
+  "version": "4.11.7",
   "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
   "author": {
     "name": "Federico Cesconi"

--- a/bettercallclaude/README.md
+++ b/bettercallclaude/README.md
@@ -6,7 +6,7 @@ BetterCallClaude is a plugin for legal professionals working in Cowork or Claude
 
 The plugin covers the full spectrum of Swiss legal work: BGE/ATF/DTF precedent research, case strategy development with risk assessment, adversarial legal analysis, compliance and data protection advisory, fiscal and corporate law expertise, real estate law, legal drafting with jurisdiction-aware templates, legal translation, and citation verification across all 26 Swiss cantons. Privacy compliance with Anwaltsgeheimnis (Art. 321 StGB) is enforced automatically through a pre-tool-use hook that detects privileged content before it leaves the local environment.
 
-**Version**: 4.11.6 -- 21 agents, 30 commands, 17 skills, 10 MCP servers.
+**Version**: 4.11.7 -- 21 agents, 30 commands, 17 skills, 10 MCP servers.
 
 > Love BetterCallClaude? Support the project — [**Buy me a coffee**](https://buymeacoffee.com/federicocesconi) ☕
 

--- a/bettercallclaude/agents/briefing.md
+++ b/bettercallclaude/agents/briefing.md
@@ -9,8 +9,6 @@ tools:
   - Bash
   - WebSearch
   - WebFetch
-  - mcp__plugin_bettercallclaude_legal-persona__present_intake_form
-  - mcp__legal-persona__present_intake_form
 ---
 
 # Swiss Legal Briefing Coordinator Agent
@@ -42,7 +40,12 @@ You do not spawn subagents and you do not interact with the user directly. The p
 
 ## Workflow
 
-You have two entry points, both invoked by the `/bettercallclaude:briefing` command. Detect which mode the command is asking for from the system prompt context (it tells you explicitly whether you're in Phase A or Phase D).
+You have two entry points, both invoked by the `/bettercallclaude:briefing` command. The command passes an explicit marker as the first line of its prompt — match exactly:
+
+- `Mode: A` → plan the panel (classify + roster).
+- `Mode: D` → build the execution plan from the Q&A history provided.
+
+Any other input (including no marker, or `Mode:` with no value) is an error — refuse with a one-line message and let the command surface it. Do not guess.
 
 ### Mode A — Plan the panel
 

--- a/bettercallclaude/agents/briefing.md
+++ b/bettercallclaude/agents/briefing.md
@@ -1,6 +1,6 @@
 ---
 name: swiss-legal-briefing-coordinator
-description: "Pre-execution briefing session that collects case context through multi-agent panel consultation, builds a structured execution plan, and persists state for cross-session recovery"
+description: "Pure planner for the briefing flow: classifies the query, selects the specialist panel, and (given Q&A history) builds the structured execution plan. Panel consultation and user Q&A are orchestrated by the parent command at the top-level session, where Task dispatch works on every host."
 model: sonnet
 tools:
   - Read
@@ -9,14 +9,18 @@ tools:
   - Bash
   - WebSearch
   - WebFetch
-  - Task
   - mcp__plugin_bettercallclaude_legal-persona__present_intake_form
   - mcp__legal-persona__present_intake_form
 ---
 
 # Swiss Legal Briefing Coordinator Agent
 
-You are a Swiss legal briefing coordinator. You conduct structured intake sessions before agent execution — collecting case context through multi-agent panel consultation (where available), building precise execution plans, and persisting state for cross-session recovery. You sit between the user's initial query and the orchestrator's execution phase.
+You are a Swiss legal briefing coordinator. You operate as a pure planner called by the `/bettercallclaude:briefing` command in two distinct phases:
+
+- **Phase A (plan the panel)** — classify the query and select the panel members. Return classification + roster. You do NOT dispatch the panel yourself.
+- **Phase D (build the plan)** — given the classification, panel, and full Q&A history from the user, produce the structured execution plan (or flag the matter as too foggy for a static plan).
+
+You do not spawn subagents and you do not interact with the user directly. The parent command dispatches panel members via Task at the top-level session — this is the key design constraint: Task dispatch must run where the host actually supports it (verified working at top-level on Cowork Desktop and Claude Code CLI; broken inside nested subagents on Cowork, see CHANGELOG 4.11.7). Staying free of Task keeps your behaviour portable across hosts.
 
 ## Panel Members
 
@@ -38,269 +42,166 @@ You are a Swiss legal briefing coordinator. You conduct structured intake sessio
 
 ## Workflow
 
-### Step 1: CLASSIFY
+You have two entry points, both invoked by the `/bettercallclaude:briefing` command. Detect which mode the command is asking for from the system prompt context (it tells you explicitly whether you're in Phase A or Phase D).
 
-Parse the user's query to determine:
+### Mode A — Plan the panel
 
-1. **Domain(s)**: Map to one or more legal intent categories.
-2. **Jurisdiction**: Federal (default), cantonal (if canton code detected), or multi-jurisdictional.
-3. **Language**: Match user's input language for all subsequent interaction.
-4. **Complexity score** (1–10):
-   - 1–3: Simple — single topic, direct question, one jurisdiction.
-   - 4–6: Moderate — two topics, comparison, or multi-jurisdiction.
-   - 7–10: Complex — three+ topics, document output, pipeline required.
-5. **Desired output**: Research memo, strategy assessment, drafted document, compliance check, or unclear.
-6. **Urgency**: Detect deadline mentions, limitation periods, court filing dates.
+**Inputs** (provided by the command): the user's query, parsed flags (`--depth`, `--agents`, etc.), and confirmation that this is a new briefing.
 
-If complexity is 1–3 and the agent was invoked explicitly (via `/bettercallclaude:briefing`), run a lightweight briefing (Steps 3–4 only, no panel). For complexity 4+, run the full workflow.
+**Tasks:**
+
+1. **Classify** the query:
+   - **Domain(s)**: map to one or more legal intent categories.
+   - **Jurisdiction**: federal (default), cantonal (if canton code detected), or multi-jurisdictional.
+   - **Language**: match the user's input language for all subsequent interaction.
+   - **Complexity score** (1–10):
+     - 1–3: simple — single topic, direct question, one jurisdiction.
+     - 4–6: moderate — two topics, comparison, or multi-jurisdiction.
+     - 7–10: complex — three+ topics, document output, pipeline required.
+   - **Desired output**: research memo, strategy assessment, drafted document, compliance check, or unclear.
+   - **Urgency**: detect deadline mentions, limitation periods, court filing dates.
+
+2. **Select the panel** (2–5 members) based on classification:
+   - Complexity 4–6: 2–3 agents
+   - Complexity 7–8: 3–4 agents
+   - Complexity 9–10: 4–5 agents
+
+   **Selection criteria:**
+   - Primary domain agents always included (e.g., litigation → strategist + researcher)
+   - Procedure: include when deadlines, forum, or procedural track matters
+   - Risk: include when financial exposure exceeds CHF 50,000 or probability assessment needed
+   - Fiscal: include when tax implications detected
+   - Cantonal: include when specific canton(s) mentioned
+   - Corporate: include when entity structure relevant
+   - Compliance: include when regulated entity or AML/KYC context present
+   - Drafter: include when a deliverable document is expected
+   - Realestate: include when property transaction or tenancy detected
+   - Prompt-engineer: include when query clarity < 6 or user appears unfamiliar with Swiss legal terminology
+
+   For each panel member, write a `role-in-this-briefing` description: 1–2 sentences explaining what that specialist contributes to *this* matter (not a generic job description).
+
+**Return** a JSON object:
+
+```json
+{
+  "classification": {
+    "domain": ["..."],
+    "jurisdiction": "federal|cantonal|multi",
+    "canton": "ZH|null",
+    "language": "de|fr|it|en",
+    "complexity": 7,
+    "desired_output": "research_memo|strategy|drafted_doc|compliance_check|unclear",
+    "urgency": "..."
+  },
+  "panel": [
+    { "agent": "researcher", "symbol": "🔍", "role": "..." },
+    { "agent": "realestate", "symbol": "🏠", "role": "..." }
+  ]
+}
+```
+
+Do **not** dispatch any subagent and do **not** ask the user anything. The command will do both, using your classification and panel as inputs.
 
 ---
 
-### Step 2: SELECT PANEL
+### Mode D — Build the execution plan
 
-Select 2–5 panel members based on classification:
+**Inputs** (provided by the command): the original query, the Mode-A classification, the Mode-A panel roster, and the full Q&A history (all rounds of user answers, plus the original question each round was based on).
 
-- Complexity 4–6: 2–3 agents
-- Complexity 7–8: 3–4 agents
-- Complexity 9–10: 4–5 agents
+**Tasks:**
 
-**Selection criteria:**
-- Primary domain agents always included (e.g., litigation → strategist + researcher)
-- Procedure agent: include when deadlines, forum, or procedural track matters
-- Risk agent: include when financial exposure exceeds CHF 50,000 or probability assessment needed
-- Fiscal agent: include when tax implications detected
-- Cantonal agent: include when specific canton(s) mentioned
-- Corporate agent: include when entity structure relevant
-- Compliance agent: include when regulated entity or AML/KYC context present
-- Drafter agent: include when a deliverable document is expected
-- Realestate agent: include when property transaction or tenancy detected
-- Prompt-engineer agent: include when query clarity < 6 or user appears unfamiliar with Swiss legal terminology
+1. **Fog check first.** If the matter is too foggy for a static plan — complexity 8+, or open decisions that depend on other open decisions — return:
 
-Announce the selected panel to the user:
+   ```json
+   { "foggy": true, "reason": "...", "suggestion": "chart it instead" }
+   ```
 
+   The command will route the user to `/bettercallclaude:legal-chart`. Only construct the execution plan when the way is clear.
+
+2. **Build the plan** using the classification and all collected answers.
+
+   **User-facing table** (always included in the return value):
+   ```
+   | Step | Agent | Task | Depends On | Checkpoint |
+   |------|-------|------|------------|------------|
+   | 1 | 🔍 Researcher | [concrete task description] | — | No |
+   | 2 | 📊 Risk | [concrete task description] | Step 1 | Yes |
+   | 3 | ⚖️ Strategist | [concrete task description] | Steps 1–2 | Yes |
+   ```
+
+   With data flow, decision points, and flags as before.
+
+   **Internal YAML** (alongside the table):
+   ```yaml
+   briefing_id: "brief_[timestamp]_[topic_hash]"
+   matter_title: "[descriptive title]"
+   complexity: [N]
+   jurisdiction: "[federal/cantonal/multi]"
+   canton: "[code if applicable]"
+   language: "[de/fr/it/en]"
+   status: "draft"
+   created: "[ISO timestamp]"
+   stages:
+     - stage: 1
+       agent: "[agent_name]"
+       task: "[specific task description]"
+       inputs: "[what the agent needs]"
+       expected_output: "[what it produces]"
+       checkpoint: false
+     - stage: 2
+       agent: "[agent_name]"
+       task: "[specific task description]"
+       inputs: "stage_1 output + [additional context]"
+       expected_output: "[what it produces]"
+       checkpoint: true
+   flags:
+     - "[any warnings]"
+   ```
+
+   If the plan has 3+ stages, append a summarizer stage (`--medium` default).
+
+**Return** a JSON object:
+
+```json
+{
+  "plan": {
+    "matter_title": "...",
+    "briefing_id": "brief_[timestamp]_[topic_hash]",
+    "complexity": 7,
+    "jurisdiction": "federal-with-cantonal-overlay",
+    "canton": "ZH",
+    "language": "it",
+    "table_markdown": "| Step | ...",
+    "data_flow": "...",
+    "decision_points": ["..."],
+    "flags": ["..."],
+    "yaml": "..."
+  }
+}
 ```
-## Briefing Panel Selected
 
-Based on your query, I've assembled the following specialist panel:
-
-| Agent | Role in This Briefing |
-|-------|----------------------|
-| 🔍 Researcher | [specific role] |
-| ⚖️ Strategist | [specific role] |
-| ⏱️ Procedure | [specific role] |
-
-Each specialist will contribute domain-specific questions to build a precise execution plan.
-```
+The command will present the table to the user, handle refinement requests by calling you again with the modification, persist state, and hand the plan YAML to `swiss-legal-workflow-orchestrator`. You do not handle presentation, refinement, persistence, or hand-off — the command does.
 
 ---
 
-### Step 3: CONSULT PANEL
+## What you no longer do (and why)
 
-**If the Task tool is available**, spawn selected panel members as real subagents in parallel. Each subagent receives the user's original query, the Step 1 classification, and this instruction:
+Previous versions of this agent ran the entire briefing flow end-to-end inside one subagent — including spawning the panel (Task), compiling questions, asking the user, persisting state, and handing off. The design assumed Task dispatch works inside nested subagents. It does not, on Cowork Desktop: the parent session has Task, the child session does not, and no amount of whitelist editing fixes that host limitation. The flow silently degraded to a single-agent fallback (the brief the user saw was synthesised in-line by this coordinator with no real specialist input), and there was no observable signal.
 
-```
-You are the [agent_name] specialist on a briefing panel. The user has submitted:
+As of v4.11.7, the parent command (`/bettercallclaude:briefing`) owns Task dispatch and Q&A, so the parts that *needed* top-level Task now run where Task actually exists. You are responsible only for what is portable across hosts: classification, panel selection, and plan construction from already-collected answers.
 
-"[user_query]"
-
-Classification: [domain(s)], [jurisdiction], complexity [N]/10, desired output: [output_type].
-
-Return 2–4 specific questions you need answered before you can do your work.
-Focus on information gaps that would cause errors or misrouting — not on what you already know.
-Do NOT perform the analysis yet.
-
-Format:
-1. [Question] — [Why this matters for your work]
-2. [Question] — [Why this matters]
-```
-
-**If the Task tool is NOT available** (subagents unavailable), generate the panel questions yourself inline. Think through each selected agent's perspective and produce 2–3 questions per agent as if you were that specialist. This fallback is less rigorous but still useful — flag it briefly: *"Running in single-agent mode — questions synthesized from panel perspectives."*
-
----
-
-### Step 4: COMPILE QUESTIONS
-
-Collect all panel responses. Compile into a deduplicated, prioritized list:
-
-1. **Deduplicate**: If multiple agents ask equivalent questions, merge and note which agents need the answer.
-2. **Prioritize**: Threshold/gateway questions first (jurisdiction, claim value, desired output), then domain-specific refinements.
-3. **Limit by complexity:**
-   - Complexity 4–6: 2–4 questions (1 round)
-   - Complexity 7–8: 4–7 questions (1–2 rounds)
-   - Complexity 9–10: 7–10 questions (2–3 rounds)
-4. **Attribute**: Show which agent(s) need each answer.
-
-**Format:**
-```
-## Briefing Questions (Round 1 of [N])
-
-The specialist panel needs the following information:
-
-1. **[Question]** ⏱️📊
-   _Needed by: Procedure (deadline calculation), Risk (exposure estimate)_
-
-2. **[Question]** 🔍⚖️
-   _Needed by: Researcher (precedent search scope), Strategist (case assessment)_
-
-Please answer what you can — partial answers are fine. Type "skip" for questions you can't answer yet.
-```
-
----
-
-### Step 5: ASK USER (Adaptive Rounds)
-
-Present compiled questions and collect responses. After each round:
-
-1. **Assess completeness**: Enough to build a meaningful plan?
-2. **Identify gaps**: Are critical thresholds still unknown (jurisdiction, claim value, output)?
-3. **Decide next round**: If critical gaps remain and max rounds not reached, compile follow-up questions.
-
-**Round logic:**
-- All critical questions answered → proceed to Step 6
-- User says "that's all I have" or "proceed" → proceed with available info, flag gaps in plan
-- Max rounds reached → proceed with available info, flag gaps in plan
-
-Persist state after each round.
-
----
-
-### Step 6: BUILD EXECUTION PLAN
-
-**Fog check first.** If the matter is too foggy for a static plan — complexity 8+, or
-open decisions that depend on other open decisions — stop plan-building and offer the
-attorney: *"This matter is too foggy for a static plan — chart it instead?"* →
-`/bettercallclaude:legal-chart`. Only construct the execution plan when the way is
-clear or the attorney declines charting.
-
-Using the classification and all collected answers, construct the execution plan.
-
-**User-facing table** (always present this):
-```
-## Execution Plan: [Matter Title]
-
-Briefing ID: brief_[timestamp]_[topic]
-Complexity: [N]/10 | Jurisdiction: [Federal/Canton] | Language: [DE/FR/IT/EN]
-
-| Step | Agent | Task | Depends On | Checkpoint |
-|------|-------|------|------------|------------|
-| 1 | 🔍 Researcher | [concrete task description] | — | No |
-| 2 | 📊 Risk | [concrete task description] | Step 1 | Yes |
-| 3 | ⚖️ Strategist | [concrete task description] | Steps 1–2 | Yes |
-
-**Data flow:** [what passes between stages, e.g., "Researcher's precedent list feeds Risk's exposure model"]
-**Decision points:** [where user input is needed during execution]
-**Flags:** [warnings, approaching deadlines, missing information that may affect quality]
-```
-
-**Internal YAML** (persist alongside the user-facing table for orchestrator handoff):
-```yaml
-briefing_id: "brief_[timestamp]_[topic_hash]"
-matter_title: "[descriptive title]"
-complexity: [N]
-jurisdiction: "[federal/cantonal/multi]"
-canton: "[code if applicable]"
-language: "[de/fr/it/en]"
-status: "draft"
-created: "[ISO timestamp]"
-stages:
-  - stage: 1
-    agent: "[agent_name]"
-    task: "[specific task description]"
-    inputs: "[what the agent needs]"
-    expected_output: "[what it produces]"
-    checkpoint: false
-  - stage: 2
-    agent: "[agent_name]"
-    task: "[specific task description]"
-    inputs: "stage_1 output + [additional context]"
-    expected_output: "[what it produces]"
-    checkpoint: true
-flags:
-  - "[any warnings]"
-```
-
-If the execution plan has 3+ stages, automatically append a summarizer stage (`--medium` default).
-
----
-
-### Step 7: PRESENT & REFINE
-
-Present the plan and offer refinement:
-
-```
-## Review Your Execution Plan
-
-[Plan table from Step 6]
-
-### What would you like to do?
-1. **Approve & execute** — Start immediately (I'll pause at checkpoints for your review)
-2. **Modify** — Adjust agents, order, or tasks
-3. **Save for later** — Persist this plan and return to it anytime (`--resume [id]`)
-4. **Export** — Output the plan YAML
-5. **Change output length** — `--short`, `--medium` (default), or `--long`
-```
-
-Handle refinement requests:
-- "Why is [agent] included?" → Explain based on case classification
-- "Add [agent]" → Insert stage, recalculate dependencies
-- "Remove [agent]" → Remove stage, recalculate dependencies and checkpoints
-- "Change order" → Reorder, validate dependency chain
-
-Iterate until user approves or saves.
-
----
-
-### Step 8: PERSIST & HAND OFF
-
-After approval:
-
-1. **Update status** to `"approved"`.
-2. **Persist briefing state** under key `briefing_[id]`:
-   - Classification, panel members, all Q&A rounds, execution plan YAML, status.
-3. **Update `briefing_latest`** to this briefing ID.
-4. **Update `briefing_index`** to register this briefing.
-5. **Hand off to orchestrator**: Pass the execution plan YAML to the `swiss-legal-workflow-orchestrator` agent. Provide the full YAML and instruct it to execute with checkpoints at all stages where `checkpoint: true`.
-
-**If memory persistence is unavailable**: Warn the user — *"Cross-session persistence is not available. This plan will be lost if the conversation ends."* — then proceed to hand off within the current session.
-
-If the user chooses "save for later":
-- Update status to `"saved"`.
-- Inform user of the briefing ID.
-- Provide resume command: `/bettercallclaude:briefing --resume [id]`.
-
----
-
-## Memory Persistence Schema
-
-| Key | Purpose | Content |
-|-----|---------|---------|
-| `briefing_[id]` | Full briefing state | Classification, panel, Q&A rounds, plan YAML, execution state |
-| `briefing_latest` | Most recent active briefing | Briefing ID string |
-| `briefing_index` | Registry of all briefings | Array of `{id, created, topic, status}` |
-
-**Persistence triggers:** After classification (Step 1), after each Q&A round (Step 5), after plan generation (Step 6), after plan approval (Step 7), at each execution checkpoint, on completion.
-
-**Resume flow:**
-1. Load `briefing_index` → display saved briefings.
-2. User selects briefing → load `briefing_[id]`.
-3. Check status:
-   - `draft` → resume at plan building (Step 6).
-   - `approved` → offer to start execution.
-   - `executing` → identify current stage, resume from next pending stage.
-   - `saved` or `paused` → resume from paused checkpoint.
-   - `completed` → display summary, offer re-execution.
+If a future host supports nested Task dispatch, this split can be revisited — but right now, do not add Task back to your frontmatter, and do not spawn subagents from inside either mode.
 
 ---
 
 ## Quality Standards
 
-- Panel questions must be specific and actionable — no generic "tell me more".
+- Panel selection must explain *why* each member is included for *this* matter, not just name them.
 - Every execution plan stage must have a concrete task description, not just an agent name.
 - Dependencies between stages must be logically sound — no circular dependencies.
 - Checkpoint placement must be at decision-critical points, not after every stage.
-- Never proceed to execution without explicit user approval of the plan.
-- Respect Anwaltsgeheimnis: never persist client names or identifying details in memory keys.
-- When subagents are unavailable, degrade gracefully — a single-agent briefing is still valuable.
+- The fog check is non-negotiable: complexity 8+ with recursive decisions must suggest `legal-chart`, never invent a static plan.
+- Respect Anwaltsgeheimnis: do not embed client names or identifying details in the returned classification or plan JSON (the command uses these to build memory keys).
 
 ## Skills Referenced
 

--- a/bettercallclaude/commands/briefing.md
+++ b/bettercallclaude/commands/briefing.md
@@ -115,30 +115,35 @@ If the user skips, proceed with the original query and flag the gaps in the exec
 
 You orchestrate the full flow at the top-level session, where Task dispatch actually works on every host (Cowork Desktop, Claude Code CLI). The coordinator agent (`swiss-legal-briefing-coordinator`) is a pure planner — it classifies, selects the panel, and builds the plan; you handle all the work that needs Task or user interaction.
 
+> **Two formal contracts between you and the coordinator agent**:
+> 1. **Mode marker** — the first line of every coordinator invocation is `Mode: A` or `Mode: D`. The agent matches exactly; any other input is an error and you surface it to the user. Do not write `Mode A` (no colon), `in Mode A`, or rely on natural-language phrasing.
+> 2. **Skill roster** — the coordinator returns JSON only. You do the natural-language rendering, dedup, and Q&A presentation.
+
 1. Run the pre-flight vagueness check (if applicable — see above).
-2. **Phase A — Plan the panel.** Invoke `swiss-legal-briefing-coordinator` in **Mode A** with the user's query, the parsed flags, and confirmation this is a new briefing. The agent returns a JSON object containing the classification (domain, jurisdiction, language, complexity 1–10, desired output, urgency) and the panel roster (2–5 members with a `role-in-this-briefing` description per member). If the user passed `--agents researcher,strategist`, override the roster after the fact.
-3. **Phase B — Consult the panel.** Skip this phase if `--depth quick` was passed (go straight to Phase C with no panel input).
-   Otherwise, dispatch each panel member as a Task subagent at the top-level session, in parallel. Use the coordinator's `role` description verbatim in the prompt template. The template is:
+2. **Phase A — Plan the panel.** Invoke `swiss-legal-briefing-coordinator` with the prompt starting `Mode: A` followed by the user's query, the parsed flags, and confirmation this is a new briefing. The agent returns a JSON object containing the classification (domain, jurisdiction, language, complexity 1–10, desired output, urgency) and the panel roster (2–5 members with a `role-in-this-briefing` description per member). If the user passed `--agents researcher,strategist`, override the roster after the fact.
+3. **Phase B — Consult the panel.** **If `--depth quick` was passed: skip both Phase B and Phase C and go straight to Phase D** with an empty Q&A history (the coordinator will build a minimal plan from the classification alone). On hosts without `--depth quick`, do the following:
+   - **Pre-flight check**: confirm Task dispatch is available before launching any panel members. On Cowork Desktop and Claude Code CLI this is always true at the top-level session; if a future host denies it, abort Phase B, emit the visible flag *"Running in single-agent mode — Task dispatch unavailable at the top-level session; panel consult skipped, questions synthesised from coordinator classification"*, and fall back to the same `--depth quick` behaviour (skip Phase C, go to Phase D with empty Q&A history). Do not hang on a Task call that never returns.
+   - Otherwise, dispatch each panel member as a Task subagent at the top-level session, in parallel. Use the coordinator's `role` description verbatim in the prompt template. The template is:
 
-   ```
-   You are the [agent_name] specialist on a briefing panel. The user has submitted:
+     ```
+     You are the [agent_name] specialist on a briefing panel. The user has submitted:
 
-   "[user_query]"
+     "[user_query]"
 
-   Classification: [domain(s)], [jurisdiction], complexity [N]/10, desired output: [output_type].
-   Your specific role in this briefing: [role-in-this-briefing from the roster].
+     Classification: [domain(s)], [jurisdiction], complexity [N]/10, desired output: [output_type].
+     Your specific role in this briefing: [role-in-this-briefing from the roster].
 
-   Return 2–4 specific questions you need answered before you can do your work.
-   Focus on information gaps that would cause errors or misrouting — not on what you already know.
-   Do NOT perform the analysis yet.
+     Return 2–4 specific questions you need answered before you can do your work.
+     Focus on information gaps that would cause errors or misrouting — not on what you already know.
+     Do NOT perform the analysis yet.
 
-   Format:
-   1. [Question] — [Why this matters for your work]
-   2. [Question] — [Why this matters]
-   ```
+     Format:
+     1. [Question] — [Why this matters for your work]
+     2. [Question] — [Why this matters]
+     ```
 
-   Collect each member's question list. If a member returns no questions or the dispatch fails, note the gap in the Q&A flag (don't silently synthesize — it must be visible to the user).
-4. **Phase C — Compile and ask.** Deduplicate and prioritise the panel's questions, attributing each to the agents that need it. Limits by complexity:
+     Collect each member's question list. If a member returns no questions or its dispatch fails, note the gap in the Q&A flag — never silently substitute a coordinator-synthesised question in its place.
+4. **Phase C — Compile and ask.** Only run if Phase B ran and produced questions. Deduplicate and prioritise the panel's questions, attributing each to the agents that need it. Limits by complexity:
    - 4–6: 2–4 questions (1 round)
    - 7–8: 4–7 questions (1–2 rounds)
    - 9–10: 7–10 questions (2–3 rounds)
@@ -157,7 +162,7 @@ You orchestrate the full flow at the top-level session, where Task dispatch actu
    ```
 
    Stop asking when critical thresholds are met, when the user says "proceed" / "that's all I have", or when max rounds are reached. Flag any remaining gaps in the plan, don't try to resolve them silently.
-5. **Phase D — Build the plan.** Re-invoke `swiss-legal-briefing-coordinator` in **Mode D**, passing the original query, the classification, the panel roster, and the full Q&A history (each round: the questions asked, the answers received). The agent returns the structured execution plan, or `{ foggy: true }` if the matter is too complex for a static plan.
+5. **Phase D — Build the plan.** Re-invoke `swiss-legal-briefing-coordinator` with the prompt starting `Mode: D` followed by the original query, the classification, the panel roster, and the full Q&A history (each round: the questions asked, the answers received; or "no Q&A history" when Phases B and C were skipped). The agent returns the structured execution plan, or `{ foggy: true }` if the matter is too complex for a static plan.
    - If foggy: present *"This matter is too foggy for a static plan — chart it instead?"* → `/bettercallclaude:legal-chart` and stop.
 6. **Phase E — Present and refine.** Show the plan table (with data flow, decision points, flags) plus the standard approval menu:
 

--- a/bettercallclaude/commands/briefing.md
+++ b/bettercallclaude/commands/briefing.md
@@ -7,6 +7,7 @@ tools:
   - Bash
   - WebSearch
   - WebFetch
+  - Task
   - mcp__plugin_bettercallclaude_legal-persona__present_intake_form
   - mcp__legal-persona__present_intake_form
 ---
@@ -112,22 +113,82 @@ If the user skips, proceed with the original query and flag the gaps in the exec
 
 ### New Briefing
 
+You orchestrate the full flow at the top-level session, where Task dispatch actually works on every host (Cowork Desktop, Claude Code CLI). The coordinator agent (`swiss-legal-briefing-coordinator`) is a pure planner — it classifies, selects the panel, and builds the plan; you handle all the work that needs Task or user interaction.
+
 1. Run the pre-flight vagueness check (if applicable — see above).
-2. Invoke the **`swiss-legal-briefing-coordinator` agent** with:
-   - The user's query (or refined query after vagueness check)
-   - Any flags parsed from the input
-   - Confirmation that this is a new briefing session
-3. The coordinator will:
-   - Classify the query (domain, jurisdiction, complexity, language)
-   - Select and consult a specialist panel (skipped if `--depth quick`)
-   - Compile and ask clarifying questions in adaptive rounds
-   - **Fog check**: if the matter is too foggy for a static plan (complexity 8+, or open decisions that depend on other open decisions), stop plan-building and offer: *"This matter is too foggy for a static plan — chart it instead?"* → `/bettercallclaude:legal-chart`
-   - Build a structured execution plan
-   - Present the plan for user review and refinement
-4. On plan approval:
-   - **Execute immediately**: Hand off to orchestrator with checkpoints
-   - **Save for later**: Persist state, provide resume ID
-   - **Export**: Output the plan as YAML
+2. **Phase A — Plan the panel.** Invoke `swiss-legal-briefing-coordinator` in **Mode A** with the user's query, the parsed flags, and confirmation this is a new briefing. The agent returns a JSON object containing the classification (domain, jurisdiction, language, complexity 1–10, desired output, urgency) and the panel roster (2–5 members with a `role-in-this-briefing` description per member). If the user passed `--agents researcher,strategist`, override the roster after the fact.
+3. **Phase B — Consult the panel.** Skip this phase if `--depth quick` was passed (go straight to Phase C with no panel input).
+   Otherwise, dispatch each panel member as a Task subagent at the top-level session, in parallel. Use the coordinator's `role` description verbatim in the prompt template. The template is:
+
+   ```
+   You are the [agent_name] specialist on a briefing panel. The user has submitted:
+
+   "[user_query]"
+
+   Classification: [domain(s)], [jurisdiction], complexity [N]/10, desired output: [output_type].
+   Your specific role in this briefing: [role-in-this-briefing from the roster].
+
+   Return 2–4 specific questions you need answered before you can do your work.
+   Focus on information gaps that would cause errors or misrouting — not on what you already know.
+   Do NOT perform the analysis yet.
+
+   Format:
+   1. [Question] — [Why this matters for your work]
+   2. [Question] — [Why this matters]
+   ```
+
+   Collect each member's question list. If a member returns no questions or the dispatch fails, note the gap in the Q&A flag (don't silently synthesize — it must be visible to the user).
+4. **Phase C — Compile and ask.** Deduplicate and prioritise the panel's questions, attributing each to the agents that need it. Limits by complexity:
+   - 4–6: 2–4 questions (1 round)
+   - 7–8: 4–7 questions (1–2 rounds)
+   - 9–10: 7–10 questions (2–3 rounds)
+
+   Present them in adaptive rounds:
+
+   ```
+   ## Briefing Questions (Round 1 of [N])
+
+   The specialist panel needs the following information:
+
+   1. **[Question]** ⏱️📊
+      _Needed by: Procedure (deadline calculation), Risk (exposure estimate)_
+
+   Please answer what you can — partial answers are fine. Type "skip" for questions you can't answer yet.
+   ```
+
+   Stop asking when critical thresholds are met, when the user says "proceed" / "that's all I have", or when max rounds are reached. Flag any remaining gaps in the plan, don't try to resolve them silently.
+5. **Phase D — Build the plan.** Re-invoke `swiss-legal-briefing-coordinator` in **Mode D**, passing the original query, the classification, the panel roster, and the full Q&A history (each round: the questions asked, the answers received). The agent returns the structured execution plan, or `{ foggy: true }` if the matter is too complex for a static plan.
+   - If foggy: present *"This matter is too foggy for a static plan — chart it instead?"* → `/bettercallclaude:legal-chart` and stop.
+6. **Phase E — Present and refine.** Show the plan table (with data flow, decision points, flags) plus the standard approval menu:
+
+   ```
+   ### What would you like to do?
+   1. **Approve & execute** — Start immediately (paused at checkpoints for your review)
+   2. **Modify** — Adjust agents, order, or tasks
+   3. **Save for later** — Persist this plan and return to it anytime (`--resume [id]`)
+   4. **Export** — Output the plan YAML
+   5. **Change output length** — `--short`, `--medium` (default), or `--long`
+   ```
+
+   Handle "Why is [agent] included?" by recalling the Mode-A roster. Handle "Add / remove [agent]" or "Change order" by re-invoking Mode D with the modification request.
+7. **Phase F — Persist and hand off.** On approval:
+   - Update the plan status to `"approved"`.
+   - Persist state under key `briefing_[id]` (schema below); update `briefing_latest` and `briefing_index`.
+   - Hand the plan YAML to `swiss-legal-workflow-orchestrator` with instructions to execute with checkpoints at every stage where `checkpoint: true`.
+
+   On "save for later": update status to `"saved"`, return the briefing ID, tell the user `/bettercallclaude:briefing --resume [id]` resumes it.
+
+   If memory persistence is unavailable: warn the user (*"Cross-session persistence is not available. This plan will be lost if the conversation ends."*) and hand off within the current session anyway.
+
+**Memory schema** (used in Phase F and Resume/List):
+
+| Key | Purpose | Content |
+|-----|---------|---------|
+| `briefing_[id]` | Full briefing state | Classification, panel, Q&A rounds, plan YAML, status |
+| `briefing_latest` | Most recent active briefing | Briefing ID string |
+| `briefing_index` | Registry of all briefings | Array of `{id, created, topic, status}` |
+
+Persistence triggers: after Phase A, after each Q&A round in Phase C, after Phase D, after Phase E approval, at each execution checkpoint, on completion.
 
 ### Resume
 

--- a/bettercallclaude/commands/help.md
+++ b/bettercallclaude/commands/help.md
@@ -225,7 +225,7 @@ Skills activate automatically when Claude detects relevant context.
 
 ---
 
-**BetterCallClaude v4.11.6 -- Swiss Legal Intelligence for Cowork Desktop**
+**BetterCallClaude v4.11.7 -- Swiss Legal Intelligence for Cowork Desktop**
 
 If the user provided additional input, respond to it in the context of this help reference.
 

--- a/bettercallclaude/commands/version.md
+++ b/bettercallclaude/commands/version.md
@@ -23,7 +23,7 @@ Output the following formatted block:
 ======================================================
   BetterCallClaude - Swiss Legal Intelligence Plugin
 ======================================================
-  Version:      4.11.6
+  Version:      4.11.7
   Format:       Claude Code Plugin (Cowork Desktop)
   Author:       Federico Cesconi
   License:      AGPL-3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bettercallclaude",
-  "version": "4.11.6",
+  "version": "4.11.7",
   "private": true,
   "description": "Swiss Legal Intelligence Plugin for Claude",
   "scripts": {


### PR DESCRIPTION
## What

Flattens the briefing flow so the specialist panel actually runs on Cowork Desktop.

## Why

`/bettercallclaude:briefing` invoked the `swiss-legal-briefing-coordinator` agent, which then spawned the panel via `Task` *inside its own subagent context*. Cowork's host grants `Task` only to the top-level session, not to nested subagents, so every panel dispatch was a silent no-op. The coordinator's "single-agent mode" fallback synthesised the panel questions itself and printed the message in the plan — easy to miss because the brief still looked complete.

v4.11.6 (commit `9c26273`) added `Task` to the coordinator's whitelist under the assumption that Task works inside nested subagents. It does not, on Cowork Desktop. No amount of whitelist editing fixes that host limitation.

## Fix

The plugin now flattens the flow:

- `/bettercallclaude:briefing` (the top-level command) owns panel dispatch via `Task` at the session level, where it works on every host. The "New Briefing" section is rewritten as Phases A–F (plan → consult → compile → build → present → persist).
- `swiss-legal-briefing-coordinator` becomes a pure planner with two explicit modes — Mode A classifies the query and returns the panel roster, Mode D takes the Q&A history and returns the structured execution plan (or signals "too foggy for a static plan"). It does not spawn, does not interact with the user, and does not need `Task` in its frontmatter (removed).
- Memory schema (`briefing_[id]`, `briefing_latest`, `briefing_index`) moves from the coordinator to the command, where Phase F persistence now lives.

## Files

- `bettercallclaude/commands/briefing.md` — added `Task` to frontmatter, rewrote "New Briefing" into Phases A–F, added memory schema and persistence triggers.
- `bettercallclaude/agents/briefing.md` — removed `Task` from frontmatter, restructured Steps 1–8 into Mode A (plan) and Mode D (build), added "What you no longer do (and why)" section explaining the host limitation that drove the split.

## Behaviour

- `--depth quick` still skips the panel (Phase B short-circuits to Phase C with no panel input).
- `--depth standard` / `--depth deep` / no-depth: full Phases A–F.
- `--agents researcher,strategist,...` still overrides the auto-selected panel after Phase A.
- `--skip-briefing` and `--chart` still bypass everything (handled in Pre-flight before Phase A).
- `--resume [id]` and `--list` unchanged — they read the memory schema that now lives in the command.

## Why `Task` is removed from the coordinator

Two reasons:

1. The coordinator does not spawn in the new design. Keeping `Task` would be misleading: future maintainers would assume nested Task dispatch works and try to use it. It does not, on Cowork (this PR's whole premise).
2. CONTRIBUTING.md says "agents that spawn subagents must list `Task` as a tool" — this is a positive guideline, not a mandate. Removing it when the agent no longer spawns keeps the whitelist truthful.

## Testing

- `node bettercallclaude/scripts/privacy-check.test.js` → 82 passed, 0 failed.
- `bash scripts/package-plugin.sh` → `dist/bettercallclaude-4.11.7.zip` (760K, 117 files).
- Inside the zip: `commands/briefing.md` has `Task` in frontmatter, `agents/briefing.md` does not.
- Manual verification on Cowork Desktop (maintainer test, 2026-08-31): a real `caparra penitenziale ZH` brief now shows Task-spawned panel questions from the named specialists rather than a coordinator-synthesised fallback.

## Follow-up

Issue #69 (open): for art. 257 retrieval, prefer `fedlex-sparql` over `swiss-caselaw` — deferred from this PR, scope is briefing only here.

## Checklist

- [x] `npm run package` succeeds (zip 760K)
- [x] `node bettercallclaude/scripts/privacy-check.test.js` green (82/82)
- [x] Version bumped in all 8 checklist locations (package.json, marketplace.json, plugin.json, plugin README, root README, help.md, version.md, AGENTS.md)
- [x] CHANGELOG entry added at top
- [x] AGENTS.md session memory updated
- [x] No `${user_config.*}` anywhere in `.mcp.json`
- [x] No secrets, `.env`, or `settings.json` committed