### PR TITLE
v4.11.8: /doctor agent-route probe + MCP tool-name parity CI guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "bettercallclaude",
       "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
-      "version": "4.11.7",
+      "version": "4.11.8",
       "source": "./bettercallclaude",
       "author": {
         "name": "Federico Cesconi"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,5 +112,8 @@ jobs:
             echo "OK: $skill_file"
           done
 
+      - name: Check MCP tool-name parity
+        run: node scripts/check-tool-names.js
+
       - name: Package plugin (dry check)
         run: bash scripts/package-plugin.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to BetterCallClaude will be documented in this file.
 
 ---
 
+## [4.11.8] - 2026-09-01
+
+### Added
+- **`/bettercallclaude:doctor` agent-route probe** — doctor previously verified only the main-session route, so it reported all-green during the v4.11.5 outage while plugin agents could not reach any connector ("No such tool available: mcp__fedlex-sparql__…"). New Step 3 dispatches the plugin's `citation-specialist` agent via `Task` with a one-shot `validate_citation` call and interprets the outcome: healthy / agent-route-broken (with update instructions) / not verifiable from a nested session. `Task` added to the doctor command's tools whitelist (same convention as `briefing.md` in 4.11.7).
+- **`scripts/check-tool-names.js` + CI step "Check MCP tool-name parity"** — every `mcp__…` entry in the `tools:` frontmatter of agents, commands, and skills must be whitelisted under both naming conventions (`mcp__plugin_bettercallclaude_<server>__<tool>` and `mcp__<server>__<tool>`), since hosts differ (scoped names on Claude Code CLI and current Cowork builds, bare server names on older Cowork builds). A missing twin silently strips the tool on the other host — the exact v4.11.5 regression. Audit of the shipped 4.11.6/4.11.7 tree: 68 files, 1658 MCP entries, all paired.
+
 ## [4.11.7] - 2026-09-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Version](https://img.shields.io/badge/version-4.11.7-blue)](https://github.com/fedec65/bettercallclaude/releases)
+[![Version](https://img.shields.io/badge/version-4.11.8-blue)](https://github.com/fedec65/bettercallclaude/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-green)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Cowork%20Desktop-orange)](https://claude.ai)
 [![Website](https://img.shields.io/badge/web-bettercallclaude.ch-brightgreen)](https://bettercallclaude.ch)
@@ -25,9 +25,9 @@ BetterCallClaude provides a structured methodology for handling legal work with 
 
 ---
 
-## What's New in v4.11.7
+## What's New in v4.11.8
 
-**v4.11.7 — Briefing panels actually run on Cowork Desktop.** `/bettercallclaude:briefing` used to spawn the specialist panel from inside the briefing coordinator (a nested subagent); Cowork's host does not grant the `Task` tool to nested subagents, so the panel dispatch silently fell back to a "single-agent mode" synthesised by the coordinator — no real specialist input, and the brief looked plausible enough that nothing surfaced. The command now owns panel dispatch via `Task` at the top-level session (where it works on every host), and the coordinator becomes a pure planner: it classifies the query, selects the panel (Mode A), then takes the Q&A history and builds the execution plan (Mode D). If you used `/briefing` and felt the output was a generic synthesis rather than a real panel consult, reinstall and try the same query — the panel questions will now come from the named specialists.
+**v4.11.8 — `/doctor` now catches a broken agent route.** In v4.11.5 an outage left plugin agents unable to reach any connector ("No such tool available") while `/doctor` reported everything green, because doctor only tested the main-session route. `/doctor` now also dispatches the plugin's citation-specialist agent for a one-shot `validate_citation` call and reports "Route agent: OK" — or, if the agent route is broken, says so plainly with update instructions. A new CI check additionally enforces that every MCP tool in agent/command/skill whitelists is registered under both naming conventions hosts use, so this regression class cannot silently return.
 
 ## What's New in v4.11.5
 

--- a/bettercallclaude/.claude-plugin/plugin.json
+++ b/bettercallclaude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bettercallclaude",
-  "version": "4.11.7",
+  "version": "4.11.8",
   "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
   "author": {
     "name": "Federico Cesconi"

--- a/bettercallclaude/README.md
+++ b/bettercallclaude/README.md
@@ -6,7 +6,7 @@ BetterCallClaude is a plugin for legal professionals working in Cowork or Claude
 
 The plugin covers the full spectrum of Swiss legal work: BGE/ATF/DTF precedent research, case strategy development with risk assessment, adversarial legal analysis, compliance and data protection advisory, fiscal and corporate law expertise, real estate law, legal drafting with jurisdiction-aware templates, legal translation, and citation verification across all 26 Swiss cantons. Privacy compliance with Anwaltsgeheimnis (Art. 321 StGB) is enforced automatically through a pre-tool-use hook that detects privileged content before it leaves the local environment.
 
-**Version**: 4.11.7 -- 21 agents, 30 commands, 17 skills, 10 MCP servers.
+**Version**: 4.11.8 -- 21 agents, 30 commands, 17 skills, 10 MCP servers.
 
 > Love BetterCallClaude? Support the project — [**Buy me a coffee**](https://buymeacoffee.com/federicocesconi) ☕
 

--- a/bettercallclaude/commands/doctor.md
+++ b/bettercallclaude/commands/doctor.md
@@ -7,6 +7,7 @@ tools:
   - Bash
   - WebSearch
   - WebFetch
+  - Task
   - mcp__plugin_bettercallclaude_bge-search__search_bge
   - mcp__bge-search__search_bge
   - mcp__plugin_bettercallclaude_entscheidsuche__search_decisions
@@ -60,7 +61,21 @@ For each of the 10 MCP servers, use a **two-stage approach**:
 | swiss-caselaw | Giurisprudenza, catene citazioni, dottrina | `search_decisions` (minimal) |
 | ollama | Classificatore privacy locale | `ollama_check_status` |
 
-## Step 3: Display Results
+## Step 3: Agent Route Probe
+
+Steps 1–2 verify the connectors from the **main session**. This step verifies the **agent route** — the path that broke in v4.11.5, when plugin agents could not see any MCP tool ("No such tool available: mcp__fedlex-sparql__…") while the main session worked fine.
+
+Dispatch the plugin's citation specialist agent via the Task tool (use its scoped name, e.g. `bettercallclaude:citation-specialist`) with exactly this prompt:
+
+> Call the legal-citations MCP tool whose name ends in `validate_citation` with the citation "BGE 145 III 229". Do not use any other tool. Report back ONLY: (1) the exact tool name you called, (2) "OK" plus the returned citation, or the verbatim error message.
+
+Interpret the result:
+
+- Agent reports a tool name + "OK" → agent route healthy; note "Route agent: OK".
+- Agent reports "No such tool available" (or cannot find any MCP tool ending in `validate_citation`) → **agent route broken**: plugin agents cannot reach the connectors even though the main session can. Tell the user to update BetterCallClaude to the latest version and re-run `/bettercallclaude:doctor`; if the problem persists, report it at https://github.com/fedec65/bettercallclaude/issues including this output.
+- The Task tool is not available in the current context (e.g. inside a nested session) → mark the route as "non verificabile" and hint to re-run `/bettercallclaude:doctor` in a fresh top-level session.
+
+## Step 4: Display Results
 
 Present results in the user's language, without technical jargon. Example (IT):
 
@@ -84,13 +99,14 @@ Present results in the user's language, without technical jargon. Example (IT):
 
   Gateway: https://mcp.bettercallclaude.ch — online
   Servizi attivi: 9/10
+  Route agent (MCP via subagent): ✓ operativa
 
 ╚══════════════════════════════════════════════════════════╝
 ```
 
 Adapt labels to DE/FR/EN based on user language.
 
-## Step 4: Guidance
+## Step 5: Guidance
 
 ### All servers active:
 > Tutti i servizi sono operativi. BetterCallClaude funziona a piena capacità.

--- a/bettercallclaude/commands/help.md
+++ b/bettercallclaude/commands/help.md
@@ -225,7 +225,7 @@ Skills activate automatically when Claude detects relevant context.
 
 ---
 
-**BetterCallClaude v4.11.7 -- Swiss Legal Intelligence for Cowork Desktop**
+**BetterCallClaude v4.11.8 -- Swiss Legal Intelligence for Cowork Desktop**
 
 If the user provided additional input, respond to it in the context of this help reference.
 

--- a/bettercallclaude/commands/version.md
+++ b/bettercallclaude/commands/version.md
@@ -23,7 +23,7 @@ Output the following formatted block:
 ======================================================
   BetterCallClaude - Swiss Legal Intelligence Plugin
 ======================================================
-  Version:      4.11.7
+  Version:      4.11.8
   Format:       Claude Code Plugin (Cowork Desktop)
   Author:       Federico Cesconi
   License:      AGPL-3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bettercallclaude",
-  "version": "4.11.7",
+  "version": "4.11.8",
   "private": true,
   "description": "Swiss Legal Intelligence Plugin for Claude",
   "scripts": {

--- a/scripts/check-tool-names.js
+++ b/scripts/check-tool-names.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Check MCP tool-name parity in `tools:` frontmatter of agents, commands, and skills.
+ *
+ * Every MCP entry whitelisted under one naming convention must also be whitelisted
+ * under the other:
+ *   scoped (Claude Code CLI / current Cowork): mcp__plugin_bettercallclaude_<server>__<tool>
+ *   bare   (older Cowork Desktop builds):       mcp__<server>__<tool>
+ *
+ * A missing twin silently strips the tool from the agent's allowlist on the host that
+ * uses the other convention — the v4.11.5 "No such tool available" regression.
+ *
+ * Usage:
+ *   node scripts/check-tool-names.js            # check (exit 1 on violation)
+ *
+ * To regenerate a file's tools: block, see scripts/generate-tool-frontmatter.js.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const pluginDir = path.join(root, 'bettercallclaude');
+
+const TARGETS = [
+  path.join(pluginDir, 'agents'),
+  path.join(pluginDir, 'commands'),
+  path.join(pluginDir, 'skills'),
+];
+
+const SCOPED_PREFIX = 'mcp__plugin_bettercallclaude_';
+const BARE_PREFIX = 'mcp__';
+
+function collectFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // skills/<name>/SKILL.md
+      const skill = path.join(p, 'SKILL.md');
+      if (fs.existsSync(skill)) out.push(skill);
+    } else if (entry.name.endsWith('.md')) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function extractToolsList(content) {
+  const fm = content.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!fm) return null;
+  const lines = fm[1].split('\n');
+  const tools = [];
+  let inTools = false;
+  for (const line of lines) {
+    if (/^tools:\s*$/.test(line)) { inTools = true; continue; }
+    if (inTools) {
+      const m = line.match(/^\s+-\s+(\S+)\s*$/);
+      if (m) { tools.push(m[1]); continue; }
+      // Any other non-indented key ends the block
+      if (/^\S/.test(line)) break;
+    }
+  }
+  return tools;
+}
+
+function parseMcpEntry(entry) {
+  let rest = null;
+  let scoped = false;
+  if (entry.startsWith(SCOPED_PREFIX)) {
+    rest = entry.slice(SCOPED_PREFIX.length);
+    scoped = true;
+  } else if (entry.startsWith(BARE_PREFIX)) {
+    rest = entry.slice(BARE_PREFIX.length);
+  } else {
+    return null; // generic tool (Read, Bash, Task, ...)
+  }
+  const i = rest.indexOf('__');
+  if (i === -1) return null; // server-level pattern like mcp__<server>
+  return { server: rest.slice(0, i), tool: rest.slice(i + 2), scoped };
+}
+
+function twinOf(e) {
+  return e.scoped
+    ? `${BARE_PREFIX}${e.server}__${e.tool}`
+    : `${SCOPED_PREFIX}${e.server}__${e.tool}`;
+}
+
+let filesChecked = 0;
+let mcpEntries = 0;
+const violations = [];
+
+for (const dir of TARGETS) {
+  if (!fs.existsSync(dir)) continue;
+  for (const file of collectFiles(dir)) {
+    const tools = extractToolsList(fs.readFileSync(file, 'utf8'));
+    if (!tools) continue;
+    filesChecked++;
+    const set = new Set(tools);
+    for (const entry of tools) {
+      const parsed = parseMcpEntry(entry);
+      if (!parsed) continue;
+      mcpEntries++;
+      const twin = twinOf(parsed);
+      if (!set.has(twin)) {
+        violations.push({ file: path.relative(root, file), entry, twin });
+      }
+    }
+  }
+}
+
+if (violations.length) {
+  console.error(`FAIL: ${violations.length} MCP tool entr${violations.length === 1 ? 'y' : 'ies'} missing its twin naming convention:\n`);
+  for (const v of violations) {
+    console.error(`  ${v.file}`);
+    console.error(`    has:    ${v.entry}`);
+    console.error(`    misses: ${v.twin}`);
+  }
+  console.error('\nBoth conventions must be whitelisted (hosts differ: scoped vs bare server names).');
+  console.error('Fix: add the missing twin, or regenerate with `node scripts/generate-tool-frontmatter.js --apply`.');
+  process.exit(1);
+}
+
+console.log(`OK: ${filesChecked} files checked, ${mcpEntries} MCP entries, all paired under both naming conventions.`);


### PR DESCRIPTION
## Summary

Safety net for the v4.11.6 dual-naming fix (the reported "No such tool available: mcp__fedlex-sparql__get_article" outage, where /doctor passed all-green while the agent route was broken):

- **/doctor agent-route probe** (`bettercallclaude/commands/doctor.md`): new Step 3 dispatches the plugin's `citation-specialist` agent via `Task` from the top-level command (Cowork grants `Task` only to the top-level session — learned in 4.11.7) for a one-shot `validate_citation` call. Outcomes: healthy / agent-route-broken (with update instructions) / not verifiable from a nested session. `Task` added to the doctor tools whitelist (same convention as `briefing.md`).
- **MCP tool-name parity guard** (`scripts/check-tool-names.js` + CI step "Check MCP tool-name parity"): every `mcp__…` entry in agents/commands/skills `tools:` frontmatter must be whitelisted under both naming conventions (scoped `mcp__plugin_bettercallclaude_<server>__<tool>` ↔ bare `mcp__<server>__<tool>`), since hosts differ. A missing twin silently strips the tool on the other host — the exact v4.11.5 regression. Protects the shipped approach instead of banning names.
- Version bump to 4.11.8 (package.json, plugin.json, marketplace.json), CHANGELOG entry.

## Verification

- `node scripts/check-tool-names.js` → OK: 68 files, 1658 MCP entries, all paired (audit of shipped 4.11.6/4.11.7 tree came back clean)
- `node bettercallclaude/scripts/privacy-check.test.js` → 82 passed, 0 failed
- doctor.md frontmatter YAML parses; `Task` present
- `bash scripts/package-plugin.sh` → dist/bettercallclaude-4.11.8.zip builds (117 files, doctor.md included)

## Note on the branch

Branched off `main` instead of `dev`: `dev` currently carries in-flight briefing follow-ups (d3b01b5) plus the pre-merge twin of the 4.11.7 commit (2847174), so a `dev`→`main` PR would bundle unreviewed work. That work stays untouched for its own PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fedec65/bettercallclaude/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## User-visible impact (per CONTRIBUTING — plugin.json changed)

- The `plugin.json` change is version-only. No MCP servers, hooks, or permissions were added or changed, so **no re-prompt or new connector consent is expected on next enable** — existing "Always allow" approvals carry over unchanged.
- The new `Task` entry in `doctor.md`'s tools whitelist references a built-in tool (not an MCP server); on hosts that ignore command tool lists it is inert documentation. No enable-time prompt results from it.

## Review follow-ups (Devin)

- Version bump completed across user-facing strings: root README badge + What's New, `bettercallclaude/README.md`, `/help` footer, `/version` status output (21b62bb). Remaining `4.11.7` references are historical only (CHANGELOG entries, `briefing.md` design notes citing CHANGELOG 4.11.7).
- Enable-time impact documented above.
